### PR TITLE
increased max header size because of large auth tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ test: uninstall install
 	cd tests && nosetests -v --with-coverage --cover-package=vlab_power_api
 
 images: build
-	sudo docker build -f ApiDockerfile -t willnx/vlab-power-api .
-	sudo docker build -f WorkerDockerfile -t willnx/vlab-power-worker .
+	docker build -f ApiDockerfile -t willnx/vlab-power-api .
+	docker build -f WorkerDockerfile -t willnx/vlab-power-worker .
 
 up:
 	docker-compose -p vlabPower up --abort-on-container-exit

--- a/vlab_power_api/app.ini
+++ b/vlab_power_api/app.ini
@@ -11,3 +11,4 @@ uid = nobody
 gid = nobody
 disable-logging = true
 enabled-threads = True
+buffer-size=32768


### PR DESCRIPTION
Increased max HTTP header size in uWSGI to accommodate large auth tokens.