### PR TITLE
Bug link header

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
     volumes:
       - ./vlab_power_api:/usr/lib/python3.6/site-packages/vlab_power_api
     environment:
-      - INF_VCENTER_SERVER=virtlab.igs.corp
-      - INF_VCENTER_USER=Administrator@vsphere.local
-      - INF_VCENTER_PASSWORD=1.Password
+      - INF_VCENTER_SERVER=ChangeME
+      - INF_VCENTER_USER=ChangeME
+      - INF_VCENTER_PASSWORD=ChangeME
       - INF_VCENTER_TOP_LVL_DIR=/vlab
 
   power-broker:

--- a/tests/test_power_api.py
+++ b/tests/test_power_api.py
@@ -50,6 +50,17 @@ class TestPowerView(unittest.TestCase):
 
         self.assertEqual(result, expected)
 
+    def test_post_task_link(self):
+        """POST on /api/1/inf/power sets the Link header"""
+        resp = self.app.post('/api/1/inf/power',
+                             headers={'X-Auth': self.token},
+                             json={'power': "on", "machine": "my VM"})
+
+        task_id = resp.headers['Link']
+        expected = '<https://localhost/api/1/inf/power/task/asdf-asdf-asdf>; rel=status'
+
+        self.assertEqual(task_id, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
POST on `/api/1/inf/power` now sets the Link header to the URI for checking the status. 
See https://github.com/willnx/vlab_gateway/pull/3 for more info.