### PR TITLE
API now passes txn_id to task

### DIFF
--- a/vlab_power_api/lib/views/power.py
+++ b/vlab_power_api/lib/views/power.py
@@ -62,7 +62,7 @@ class PowerView(TaskView):
         machine = kwargs['body']['machine']
         power = kwargs['body']['power']
         txn_id = request.headers.get('X-REQUEST-ID', 'noId')
-        task = current_app.celery_app.send_task('power.modify', [username, power, machine])
+        task = current_app.celery_app.send_task('power.modify', [username, power, machine, txn_id])
         resp_data['content'] = {'task-id': task.id}
         resp = Response(ujson.dumps(resp_data))
         resp.status_code = 202


### PR DESCRIPTION
Can't really log the request id if the API doesn't pass it. What a _derp_ bug 😅 

![doh](https://i.kym-cdn.com/photos/images/original/000/925/410/4cc.jpg)